### PR TITLE
Add support for appending argument types BYTE, INT16 and UINT16.

### DIFF
--- a/src/ndbus-utils.cc
+++ b/src/ndbus-utils.cc
@@ -313,6 +313,30 @@ NDbusMessageAppendArgsReal (DBusMessageIter * iter,
         dbus_message_iter_append_basic(iter, DBUS_TYPE_BOOLEAN, &val);
         break;
       }
+    case DBUS_TYPE_BYTE:
+      {
+        if(value->Int32Value() < 0 || value->Int32Value() > 255)
+          return TYPE_MISMATCH;
+        guint8 val = value->Uint32Value();
+        dbus_message_iter_append_basic(iter, DBUS_TYPE_BYTE, &val);
+        break;
+      }
+      case DBUS_TYPE_INT16:
+      {
+        if(value->Int32Value() < -32768 || value->Int32Value() > 32767)
+          return TYPE_MISMATCH;
+        gint16 val = value->Int32Value();
+        dbus_message_iter_append_basic(iter, DBUS_TYPE_INT16, &val);
+        break;
+      }
+    case DBUS_TYPE_UINT16:
+      {
+        if(value->Int32Value() < 0 || value->Int32Value() > 65535)
+          return TYPE_MISMATCH;
+        guint16 val = value->Uint32Value();
+        dbus_message_iter_append_basic(iter, DBUS_TYPE_UINT16, &val);
+        break;
+      }
     case DBUS_TYPE_INT32:
       {
         if (!value->IsInt32())


### PR DESCRIPTION
V8 only supports 32 bit integers, but there are other integer types in the DBus spec.

I added DBUS_TYPE_BYTE, DBUS_TYPE_INT16 and DBUS_TYPE_UINT16 cases to NDbusMessageAppendArgsReal() with simple overflow checks.